### PR TITLE
Docker building things

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,19 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag watch-reminder-bot:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm ci
+
+# Bundle app source
+COPY . .
+
+RUN npm i --only=production
+
+EXPOSE 3000
+CMD [ "npm", "start" ]
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "description": "help",
   "main": "index.js",
   "scripts": {
+	"start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
- `package.json`: Adds a script so you can run `npm start` conventionally
- `Dockerfile`: Instructions on how to build a Docker image from the repo
- `.github/workflows/docker-image.yml`: Instructions to make GitHub automatically build the Docker image when something is pushed to `main`. **NOTE:** GitHub has limits on how many free minutes you get with this, I don't know if you already use GitHub actions but frequent pushes might interfere with that, if so we should change this to a release branch or something similar so it's not building constantly.